### PR TITLE
Automata4j-API: Fix javadoc and code enhancements

### DIFF
--- a/automata4j-examples/src/main/java/com/avrsandbox/fsa/example/SerialAdder.java
+++ b/automata4j-examples/src/main/java/com/avrsandbox/fsa/example/SerialAdder.java
@@ -38,6 +38,7 @@ import com.avrsandbox.fsa.core.TransitionalManager;
 import com.avrsandbox.fsa.core.state.AutoState;
 import com.avrsandbox.fsa.core.state.CloneType;
 import com.avrsandbox.fsa.core.state.TransitionListener;
+import com.avrsandbox.fsa.util.AutomataLogger;
 
 /**
  * A tech-demo demonstrating a basic example of an antegrade finite-state-automaton design pattern.
@@ -70,7 +71,9 @@ public final class SerialAdder extends Thread implements TransitionListener {
      * Initializes the AutoStates and assigns the entry state.
      */
     public void init() {
-        
+        /* enables automata logger */
+        AutomataLogger.setEnabled(true);
+
         /* create bits to add */
         adders.add(new BitsAdder(0, 0));
         adders.add(new BitsAdder(0, 1));

--- a/automata4j-examples/src/main/java/com/avrsandbox/fsa/example/deterministic/TestDeterministicFiniteState.java
+++ b/automata4j-examples/src/main/java/com/avrsandbox/fsa/example/deterministic/TestDeterministicFiniteState.java
@@ -34,6 +34,8 @@ package com.avrsandbox.fsa.example.deterministic;
 import com.avrsandbox.fsa.core.TransitionalManager;
 import com.avrsandbox.fsa.core.deterministic.DeterministicManager;
 import com.avrsandbox.fsa.core.state.AutoState;
+import com.avrsandbox.fsa.core.state.TransitionListener;
+import com.avrsandbox.fsa.util.AutomataLogger;
 import com.avrsandbox.fsa.util.TransitionPath;
 
 /**
@@ -44,6 +46,7 @@ import com.avrsandbox.fsa.util.TransitionPath;
  */
 public final class TestDeterministicFiniteState {
     public static void main(String[] args) {
+        AutomataLogger.setEnabled(true);
 
         final ArmatureState idleState = new ArmatureState();
         idleState.setInput("Idle");
@@ -57,9 +60,13 @@ public final class TestDeterministicFiniteState {
 
         final TransitionalManager transitionalManager = new DeterministicManager();
         /* repeat the transition path to assert the TransitionPathNotUniqueException */
-        transitionalManager.transit(transitionPath, null);
-
-        transitionalManager.transit(transitionPath, null);
+        transitionalManager.transit(transitionPath, new TransitionListener() {
+            @Override
+            public <I, O> void onTransition(AutoState<I, O> presentState) {
+                transitionalManager.transit(null);
+                transitionalManager.transit(transitionPath, null);
+            }
+        });
     }
 
     protected static final class ArmatureState implements AutoState<String, String> {
@@ -74,7 +81,7 @@ public final class TestDeterministicFiniteState {
 
         @Override
         public void invoke(String input) {
-            tracer = "Armature is " + input;
+            tracer = "Armature is " + this.input;
             System.out.println(tracer);
         }
 

--- a/automata4j/src/main/java/com/avrsandbox/fsa/core/Transition.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/core/Transition.java
@@ -33,14 +33,15 @@ package com.avrsandbox.fsa.core;
 
 import com.avrsandbox.fsa.core.state.AutoState;
 import com.avrsandbox.fsa.core.state.NextStateNotFoundException;
-import com.avrsandbox.fsa.core.state.TransitionListener;
 
 /**
  * Represents a machine system transition with one next-state {@link Transition#nextState}.
- * 
+ *
+ * @param <S> a type of {@link AutoState}
  * @author pavl_g
  */
-public final class Transition<S extends AutoState<?, ?>> {
+@SuppressWarnings("rawtypes")
+public final class Transition<S extends AutoState> {
     
     private S nextState;
 
@@ -61,11 +62,16 @@ public final class Transition<S extends AutoState<?, ?>> {
 
     /**
      * Assigns a next-state into your heap memory.
-     * Default value is (null).
+     * Default value is (not-null).
      * 
      * @param nextState the next-state object to assign
+     * @throws NextStateNotFoundException thrown if the next-state is null
      */
     public void setNextState(S nextState) {
+        /* a business exception if there is no next-state assigned */
+        if (nextState == null) {
+            throw new NextStateNotFoundException();
+        }
         this.nextState = nextState;
     }
 
@@ -73,14 +79,8 @@ public final class Transition<S extends AutoState<?, ?>> {
      * Loads the state from your heap into your stack memory.
      * 
      * @return the next state of the transition system
-     * @throws NextStateNotFoundException thrown if the {@link TransitionalManager#transit(Object, TransitionListener)}
-     * is called without assigning a next state
      */
     public S getNextState() throws NextStateNotFoundException {
-        /* a business exception if there is no next-state assigned */
-        if (nextState == null) {
-            throw new NextStateNotFoundException();
-        }
         return nextState;
     }
 

--- a/automata4j/src/main/java/com/avrsandbox/fsa/core/TransitionalManager.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/core/TransitionalManager.java
@@ -34,7 +34,6 @@ package com.avrsandbox.fsa.core;
 import java.util.logging.Level;
 import java.lang.Thread;
 import com.avrsandbox.fsa.core.state.AutoState;
-import com.avrsandbox.fsa.core.state.NextStateNotFoundException;
 import com.avrsandbox.fsa.core.state.TransitionListener;
 import com.avrsandbox.fsa.util.AutomataLogger;
 import com.avrsandbox.fsa.util.TransitionPath;

--- a/automata4j/src/main/java/com/avrsandbox/fsa/core/deterministic/DeterministicManager.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/core/deterministic/DeterministicManager.java
@@ -58,6 +58,13 @@ public class DeterministicManager extends TransitionalManager {
      */
     protected Map<String, TransitionPath> paths = new HashMap<>();
 
+    /**
+     * Instantiates a deterministic finite-state-automaton manager that
+     * defines a single a-successor path (unique transition paths).
+     */
+    public DeterministicManager() {
+    }
+
     @Override
     public <I, O> void transit(TransitionPath<AutoState<I, O>> transitionPath, TransitionListener transitionListener) {
         if (hasTransitionPath(transitionPath)) {

--- a/automata4j/src/main/java/com/avrsandbox/fsa/core/deterministic/DeterministicManager.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/core/deterministic/DeterministicManager.java
@@ -49,6 +49,7 @@ import java.util.Map;
  *
  * @author pavl_g
  */
+@SuppressWarnings("rawtypes")
 public class DeterministicManager extends TransitionalManager {
 
     /**

--- a/automata4j/src/main/java/com/avrsandbox/fsa/core/deterministic/DeterministicManager.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/core/deterministic/DeterministicManager.java
@@ -84,10 +84,11 @@ public class DeterministicManager extends TransitionalManager {
         if (transitionPath == null) {
             throw new IllegalArgumentException("Cannot accept null transition paths!");
         }
-        return paths.get(transitionPath.getName()) != null &&
-                (paths.get(transitionPath.getName()) == transitionPath ||
-                (paths.get(transitionPath.getName()).getPresentState().hashCode() == transitionPath.getPresentState().hashCode() &&
-                paths.get(transitionPath.getName()).getNextState().hashCode() == transitionPath.getNextState().hashCode() &&
-                paths.get(transitionPath.getName()).getNextState().getInput().hashCode() == transitionPath.getNextState().getInput().hashCode()));
+        TransitionPath transitionPath1 = paths.get(transitionPath.getName());
+        return transitionPath1 != null &&
+                (transitionPath1.hashCode() == transitionPath.hashCode() ||
+                        (transitionPath1.getPresentState().hashCode() == transitionPath.getPresentState().hashCode() &&
+                                transitionPath1.getNextState().hashCode() == transitionPath.getNextState().hashCode() &&
+                                transitionPath1.getNextState().getInput().hashCode() == transitionPath.getNextState().getInput().hashCode()));
     }
 }

--- a/automata4j/src/main/java/com/avrsandbox/fsa/core/state/NextStateNotFoundException.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/core/state/NextStateNotFoundException.java
@@ -34,17 +34,17 @@ package com.avrsandbox.fsa.core.state;
 import com.avrsandbox.fsa.core.TransitionalManager;
 
 /**
- * Loaded into the stack and disptached as a result of trying to call {@link TransitionalManager#transit(Object, TransitionListener)}
- * without assigning a next state or as a result of removing the state from the heap before transitting the system.
+ * Loaded into the stack and dispatched as a result of trying to call {@link TransitionalManager#transit(Object, TransitionListener)}
+ * without assigning a next state or as a result of removing the state from the heap before transiting the system.
  * 
  * @author pavl_g
  */
 public class NextStateNotFoundException extends NullPointerException {
     
     /**
-     * Instantiates a new exception as a result of transitting into an empty next-state.
+     * Instantiates a new exception as a result of transiting into an empty next-state.
      */
     public NextStateNotFoundException() {
-        super("Next-State of the transition is not found !");
+        super("Next-State of the transition is not found!");
     }
 }

--- a/automata4j/src/main/java/com/avrsandbox/fsa/core/state/TransitionListener.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/core/state/TransitionListener.java
@@ -44,7 +44,7 @@ import com.avrsandbox.fsa.core.TransitionalManager;
 public interface TransitionListener {
     
     /**
-     * Dispatched as a result of commiting a call to {@link TransitionalManager#transit(Object, TransitionListener)}.
+     * Dispatched as a result of committing a call to {@link TransitionalManager#transit(Object, TransitionListener)}.
      * 
      * Applications should decide how they want to transit to other states from here by selectively assigning them 
      * based on some system conditions, the API provides a carrier for these system conditions on the tracer object

--- a/automata4j/src/main/java/com/avrsandbox/fsa/util/AutomataLogger.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/util/AutomataLogger.java
@@ -1,0 +1,96 @@
+/*
+ * BSD 3-Clause License
+ *
+ * Copyright (c) 2023, The AvrSandbox Project, Automata4j
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice, this
+ *   list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *   this list of conditions and the following disclaimer in the documentation
+ *   and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *   contributors may be used to endorse or promote products derived from
+ *   this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+package com.avrsandbox.fsa.util;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Defines a general-purpose utility for logging events, use
+ * {@link AutomataLogger#setEnabled(boolean)} to control whether to
+ * enable or disable this utility.
+ *
+ * @author pavl_g
+ */
+public final class AutomataLogger {
+
+    private static final Logger logger = Logger.getLogger("Automata4j-core");
+    private static boolean enabled;
+
+    private AutomataLogger() {
+    }
+
+    /**
+     * Logs an event with a logging level and a message.
+     *
+     * @param level the logging level
+     * @param msg a message to log
+     */
+    public static void log(Level level, String msg) {
+        if (!enabled) {
+            return;
+        }
+        logger.log(level, msg);
+    }
+
+    /**
+     * Logs a throwable event with a logging level and a message.
+     *
+     * @param level the logging level
+     * @param msg a message to log
+     * @param throwable a throwable event
+     */
+    public static void log(Level level, String msg, Throwable throwable) {
+        if (!enabled) {
+            return;
+        }
+        logger.log(level, msg, throwable);
+    }
+
+    /**
+     * Enables/Disables the framework event logger.
+     *
+     * @param enabled true to enable, false otherwise
+     */
+    public static void setEnabled(boolean enabled) {
+        AutomataLogger.enabled = enabled;
+    }
+
+    /**
+     * Tests whether the framework event logger is enabled.
+     *
+     * @return true if the event logger is enabled, false otherwise
+     */
+    public static boolean isEnabled() {
+        return enabled;
+    }
+}

--- a/automata4j/src/main/java/com/avrsandbox/fsa/util/AutomataLogger.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/util/AutomataLogger.java
@@ -52,9 +52,9 @@ public final class AutomataLogger {
     /**
      * Logs an event with a logging level and a message.
      *
+     * @param level the logging level
      * @param sourceClass the class source
      * @param sourceMethod the dispatching method
-     * @param level the logging level
      * @param msg a message to log
      */
     public static void log(Level level, String sourceClass, String sourceMethod, String msg) {
@@ -67,9 +67,10 @@ public final class AutomataLogger {
     /**
      * Logs a throwable event with a logging level and a message.
      *
+     * @param level the logging level
      * @param sourceClass the class source
      * @param sourceMethod the dispatching method
-     * @param level the logging level
+     * @param msg a message to log
      * @param throwable a throwable event
      */
     public static void log(Level level, String sourceClass, String sourceMethod, String msg, Throwable throwable) {

--- a/automata4j/src/main/java/com/avrsandbox/fsa/util/AutomataLogger.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/util/AutomataLogger.java
@@ -52,28 +52,31 @@ public final class AutomataLogger {
     /**
      * Logs an event with a logging level and a message.
      *
+     * @param sourceClass the class source
+     * @param sourceMethod the dispatching method
      * @param level the logging level
      * @param msg a message to log
      */
-    public static void log(Level level, String msg) {
+    public static void log(Level level, String sourceClass, String sourceMethod, String msg) {
         if (!enabled) {
             return;
         }
-        logger.log(level, msg);
+        logger.logp(level, sourceClass, sourceMethod, msg);
     }
 
     /**
      * Logs a throwable event with a logging level and a message.
      *
+     * @param sourceClass the class source
+     * @param sourceMethod the dispatching method
      * @param level the logging level
-     * @param msg a message to log
      * @param throwable a throwable event
      */
-    public static void log(Level level, String msg, Throwable throwable) {
+    public static void log(Level level, String sourceClass, String sourceMethod, String msg, Throwable throwable) {
         if (!enabled) {
             return;
         }
-        logger.log(level, msg, throwable);
+        logger.logp(level, sourceClass, sourceMethod, msg, throwable);
     }
 
     /**

--- a/automata4j/src/main/java/com/avrsandbox/fsa/util/TransitionPath.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/util/TransitionPath.java
@@ -31,7 +31,7 @@
 
 package com.avrsandbox.fsa.util;
 
-import com.avrsandbox.fsa.core.TransitionalManager;
+import com.avrsandbox.fsa.core.deterministic.DeterministicManager;
 import com.avrsandbox.fsa.core.state.AutoState;
 
 /**
@@ -39,7 +39,7 @@ import com.avrsandbox.fsa.core.state.AutoState;
  *
  * @param <S> a type of {@link AutoState}
  * @author pavl_g
- * @see TransitionalManager#transit(TransitionPath, com.avrsandbox.fsa.core.state.TransitionListener)
+ * @see DeterministicManager#transit(TransitionPath, com.avrsandbox.fsa.core.state.TransitionListener)
  */
 @SuppressWarnings("rawtypes")
 public final class TransitionPath<S extends AutoState> {
@@ -49,17 +49,18 @@ public final class TransitionPath<S extends AutoState> {
     private S nextState;
 
     /**
-     * Instantiates a new state map with empty states
+     * Instantiates a new transition path with empty states.
      *
-     * @param name the map name (not null)
+     * @param name the transition path name (not null)
      */
     public TransitionPath(String name) {
         this(name, null, null);
     }
 
     /**
-     * Instantiates a new state map with a present-state and a next-state.
-     * 
+     * Instantiates a new transition path with a present-state and a next-state.
+     *
+     * @param name the transition path name (not null)
      * @param presentState a present-state to transit to
      * @param nextState a next-state to assign for the next transition
      */
@@ -70,7 +71,7 @@ public final class TransitionPath<S extends AutoState> {
     }
     
     /**
-     * Assigns the present state to this map object.
+     * Assigns the present state to this transition path object.
      * 
      * @param presentState the present state object
      */
@@ -79,7 +80,7 @@ public final class TransitionPath<S extends AutoState> {
     }
     
     /**
-     * Assigns the next state to this map object.
+     * Assigns the next state to this transition path object.
      * 
      * @param nextState the next state object
      */

--- a/automata4j/src/main/java/com/avrsandbox/fsa/util/TransitionPath.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/util/TransitionPath.java
@@ -36,10 +36,12 @@ import com.avrsandbox.fsa.core.state.AutoState;
 
 /**
  * Provides a transition path composed of two states, a present-state and a next-state.
- * 
+ *
+ * @param <S> a type of {@link AutoState}
  * @author pavl_g
  * @see TransitionalManager#transit(TransitionPath, com.avrsandbox.fsa.core.state.TransitionListener)
  */
+@SuppressWarnings("rawtypes")
 public final class TransitionPath<S extends AutoState> {
 
     private String name;
@@ -103,10 +105,25 @@ public final class TransitionPath<S extends AutoState> {
         return presentState;
     }
 
+    /**
+     * Sets the name of this transition path.
+     *
+     * <p>
+     * This attribute ensures uniqueness of the transition path in
+     * case of using the {@link com.avrsandbox.fsa.core.deterministic.DeterministicManager}.
+     * </p>
+     *
+     * @param name the new name to set
+     */
     public void setName(String name) {
         this.name = name;
     }
 
+    /**
+     * Retrieves the name of this transition path.
+     *
+     * @return the name of this transition path
+     */
     public String getName() {
         return name;
     }

--- a/automata4j/src/main/java/com/avrsandbox/fsa/util/package-info.java
+++ b/automata4j/src/main/java/com/avrsandbox/fsa/util/package-info.java
@@ -30,6 +30,6 @@
  */
 
 /**
- * Provides utilities for the framework.
+ * Provides general-purpose utilities for the framework.
  */
 package com.avrsandbox.fsa.util;


### PR DESCRIPTION
This PR fixes and enhances the core API code and Javadoc, here are the most valuable additions:
- [x] Corrected the way `TransitionalManager#transit(TransitionPath, TransitionalListener)` should work by using both the present state and the next state of the specified `TranstionPath`.
- [x] Added `AutomataLogger` a general-purpose logging utility.
- [x] Suppressed raw types warnings on the `DeterministicManager`. 
- [x] Some code enhancements on the core API. 